### PR TITLE
v.0.2.0

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,7 +3,7 @@ assumeStandardLibraryStripMargin = true
 danglingParentheses = true
 docstrings = JavaDoc
 lineEndings = unix
-maxColumn = 100
+maxColumn = 140
 
 continuationIndent {
   callSite = 2
@@ -29,4 +29,4 @@ rewrite.rules = [
   RedundantParens,
   SortModifiers
 ]
-version = "2.0.0-RC5"
+version = "2.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ jdk: openjdk8
 language: scala
 scala:
 #  - 2.13.0
-  - 2.12.8
+  - 2.12.9
 #  - 2.11.12
 
 sudo: false

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,12 @@
+import spartanz.sbtorgpolicies.Formatting._
+
+inThisBuild(
+  List(
+    scalafmtOnCompile := false,
+    scalafmtGenerateConfigOnLoad := {}
+  )
+)
+
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
@@ -30,8 +39,8 @@ lazy val root =
       scalaVersion := "2.12.9",
       scalacOptions ++= Seq("-Xsource:2.13"),
       libraryDependencies ++= Seq(
-        compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
-        compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
+        compilerPlugin("org.typelevel" %% "kind-projector"     % "0.10.3"),
+        compilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1"),
         "org.scalaz" %% "scalaz-core" % "7.3.0-M30",
         "org.specs2" %% "specs2-core" % "4.6.0" % Test
       )

--- a/build.sbt
+++ b/build.sbt
@@ -27,9 +27,11 @@ lazy val root =
   (project in file("."))
     .settings(
       name := "parserz",
-      scalaVersion := "2.12.8",
+      scalaVersion := "2.12.9",
       scalacOptions ++= Seq("-Xsource:2.13"),
       libraryDependencies ++= Seq(
+        compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
+        compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
         "org.scalaz" %% "scalaz-core" % "7.3.0-M30",
         "org.specs2" %% "specs2-core" % "4.6.0" % Test
       )

--- a/src/main/scala/org/spartanz/parserz/ParsersModule.scala
+++ b/src/main/scala/org/spartanz/parserz/ParsersModule.scala
@@ -30,15 +30,15 @@ trait ParsersModule {
 
     final def ∘ [B](to: A => B, from: B => A): Grammar[SI, SO, E, B] = map(to, from)
 
-    final def ~ [SI1 <: SI, SO1 >: SO, E1 >: E, B](that: Grammar[SI1, SO1, E1, B]): Grammar[SI1, SO1, E1, A /\ B] = self zip that
+    final def ~ [SI1 <: SI, SO1 >: SO, E1 >: E, B](that: Grammar[SI1, SO1, E1, B]): Grammar[SI1, SO1, E1, A /\ B] = self.zip(that)
 
-    final def | [SI1 <: SI, SO1 >: SO, E1 >: E, B](that: Grammar[SI1, SO1, E1, B]): Grammar[SI1, SO1, E1, A \/ B] = self alt that
+    final def | [SI1 <: SI, SO1 >: SO, E1 >: E, B](that: Grammar[SI1, SO1, E1, B]): Grammar[SI1, SO1, E1, A \/ B] = self.alt(that)
 
     final def rep: Grammar[SI, SO, E, List[A]] = Rep(self)
 
     final def rep1: Grammar[SI, SO, E, ::[A]] = Rep1(self)
 
-    final def @@(tag: String): Grammar[SI, SO, E, A] = Tag(self, tag)
+    final def @@ (tag: String): Grammar[SI, SO, E, A] = Tag(self, tag)
 
     final def tag(tag: String): Grammar[SI, SO, E, A] = self @@ tag
   }
@@ -84,40 +84,40 @@ trait ParsersModule {
     }
   }
 
-  final def parser[S, E, A](grammar: Grammar[S, S, E, A]): (S, Input) => (S, E \/ (Input, A)) = {
+  final def parser[S, E, A](grammar: Grammar[S, S, E, A]): (S, Input) => (S, E \/ (Input, A)) =
     grammar match {
-      case Grammar.Unit0()              => (s: S, i: Input) => (s, Right((i, ())))
-      case Grammar.Consume0(to, _)      => (s: S, i: Input) => (s, to(i))
-      case Grammar.Consume(to, _)       => (s: S, i: Input) => to(s, i)
-      case Grammar.Tag(value, _)        => (s: S, i: Input) => parser(value)(s, i)
-      case Grammar.Delay(delayed)       => (s: S, i: Input) => parser(delayed())(s, i)
+      case Grammar.Unit0()         => (s: S, i: Input) => (s, Right((i, ())))
+      case Grammar.Consume0(to, _) => (s: S, i: Input) => (s, to(i))
+      case Grammar.Consume(to, _)  => (s: S, i: Input) => to(s, i)
+      case Grammar.Tag(value, _)   => (s: S, i: Input) => parser(value)(s, i)
+      case Grammar.Delay(delayed)  => (s: S, i: Input) => parser(delayed())(s, i)
 
-      case Grammar.Map(value, to, _)    =>
+      case Grammar.Map(value, to, _) =>
         (s: S, i: Input) => {
           val (s1, res1) = parser(value)(s, i)
           (s1, res1.flatMap { case (i1, a) => to(a).map(i1 -> _) })
         }
 
-      case Grammar.Zip(left, right)     =>
+      case Grammar.Zip(left, right) =>
         (s: S, i: Input) => {
           val ll = left.asInstanceOf[Grammar[Any, Any, E, Any]]
           val rr = right.asInstanceOf[Grammar[Any, Any, E, Any]]
           val res = parser(ll)(s, i) match {
-            case (s1, Left(e))        =>
+            case (s1, Left(e)) =>
               (s1, Left(e))
             case (s1, Right((i1, a))) =>
               val (s2, res2) = parser(rr)(s1, i1)
               (s2, res2.map { case (i2, b) => (i2, (a, b)) })
-            }
+          }
           res.asInstanceOf[(Nothing, E \/ (Input, (Any, Any)))]
         }
 
-      case Grammar.Alt(left, right)     =>
+      case Grammar.Alt(left, right) =>
         (s: S, i: Input) => {
           val ll = left.asInstanceOf[Grammar[Any, Any, E, Any]]
           val rr = right.asInstanceOf[Grammar[Any, Any, E, Any]]
           val res = parser(ll)(s, i) match {
-            case (s1, Left(_))        =>
+            case (s1, Left(_)) =>
               val (s2, res2) = parser(rr)(s1, i)
               (s2, res2.map { case (i2, b) => (i2, Right(b)) })
             case (s1, Right((i1, a))) =>
@@ -126,18 +126,18 @@ trait ParsersModule {
           res.asInstanceOf[(Nothing, E \/ (Input, Any \/ Any))]
         }
 
-      case Grammar.Rep(value)           =>
+      case Grammar.Rep(value) =>
         (s: S, i: Input) => {
-          val vv = value.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val vv           = value.asInstanceOf[Grammar[Any, Any, E, Any]]
           val (s1, i1, as) = repeatParse(vv)(s, i, Nil)
           (s1, Right((i1, as.reverse))).asInstanceOf[(Nothing, E \/ (Input, List[Any]))]
         }
 
-      case Grammar.Rep1(value)       =>
+      case Grammar.Rep1(value) =>
         (s: S, i: Input) => {
           val vv = value.asInstanceOf[Grammar[Any, Any, E, Any]]
           val res = parser(vv)(s, i) match {
-            case (s1, Left(e))         =>
+            case (s1, Left(e)) =>
               (s1, Left(e))
             case (s1, Right((i1, a1))) =>
               val (s2, i2, as) = repeatParse(vv)(s1, i1, Nil)
@@ -146,7 +146,6 @@ trait ParsersModule {
           res.asInstanceOf[(Nothing, E \/ (Input, ::[Any]))]
         }
     }
-  }
 
   @tailrec
   private def repeatParse[S, E, A](g: Grammar[S, S, E, A])(s: S, i: Input, as: List[A]): (S, Input, List[A]) =
@@ -158,31 +157,31 @@ trait ParsersModule {
 
   final def printer[S, E, A](grammar: Grammar[S, S, E, A]): (S, (Input, A)) => (S, E \/ Input) =
     grammar match {
-      case Grammar.Unit0()              => (s: S, a: (Input, A)) => (s, Right(a._1))
-      case Grammar.Consume0(_, from)    => (s: S, a: (Input, A)) => (s, from(a))
-      case Grammar.Consume(_, from)     => (s: S, a: (Input, A)) => from(s, a)
-      case Grammar.Tag(value, _)        => (s: S, a: (Input, A)) => printer(value)(s, a)
-      case Grammar.Delay(delayed)       => (s: S, a: (Input, A)) => printer(delayed())(s, a)
+      case Grammar.Unit0()           => (s: S, a: (Input, A)) => (s, Right(a._1))
+      case Grammar.Consume0(_, from) => (s: S, a: (Input, A)) => (s, from(a))
+      case Grammar.Consume(_, from)  => (s: S, a: (Input, A)) => from(s, a)
+      case Grammar.Tag(value, _)     => (s: S, a: (Input, A)) => printer(value)(s, a)
+      case Grammar.Delay(delayed)    => (s: S, a: (Input, A)) => printer(delayed())(s, a)
 
-      case Grammar.Map(value, _, from)  =>
+      case Grammar.Map(value, _, from) =>
         (s: S, a: (Input, A)) => {
           from(a._2).fold(e => s -> Left(e), b => printer(value)(s, (a._1, b)))
         }
 
-      case Grammar.Zip(left, right)     =>
+      case Grammar.Zip(left, right) =>
         // todo: use existential A and B here?
         (s: S, a: (Input, (Any, Any))) => {
-          val ll = left.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val rr = right.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val ll         = left.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val rr         = right.asInstanceOf[Grammar[Any, Any, E, Any]]
           val (s1, res1) = printer(ll)(s, (a._1, a._2._1)).asInstanceOf[(S, E \/ Input)]
           val res2: (S, E \/ Input) = res1 match {
-            case Left(e) => (s1, Left(e))
+            case Left(e)   => (s1, Left(e))
             case Right(i1) => printer(rr)(s1, (i1, a._2._2)).asInstanceOf[(S, E \/ Input)]
           }
           res2.asInstanceOf[(Nothing, E \/ Input)]
         }
 
-      case Grammar.Alt(left, right)     =>
+      case Grammar.Alt(left, right) =>
         (s: S, a: (Input, Any \/ Any)) => {
           val ll = left.asInstanceOf[Grammar[Any, Any, E, Any]]
           val rr = right.asInstanceOf[Grammar[Any, Any, E, Any]]
@@ -193,16 +192,16 @@ trait ParsersModule {
           res.asInstanceOf[(Nothing, E \/ Input)]
         }
 
-      case Grammar.Rep(value)           =>
+      case Grammar.Rep(value) =>
         (s: S, a: (Input, List[Any])) => {
-          val vv = value.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val vv  = value.asInstanceOf[Grammar[Any, Any, E, Any]]
           val res = repeatPrint(vv)(s, a._1, a._2)
           res.asInstanceOf[(Nothing, E \/ Input)]
         }
 
-      case Grammar.Rep1(value)          =>
+      case Grammar.Rep1(value) =>
         (s: S, a: (Input, ::[Any])) => {
-          val vv = value.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val vv  = value.asInstanceOf[Grammar[Any, Any, E, Any]]
           val res = repeatPrint(vv)(s, a._1, a._2)
           res.asInstanceOf[(Nothing, E \/ Input)]
         }
@@ -216,8 +215,4 @@ trait ParsersModule {
 
 
   final def bnf[SI, SO, E, A](grammar: Grammar[SI, SO, E, A]): String = ???
-}
-
-object ParsersModule {
-
 }

--- a/src/main/scala/org/spartanz/parserz/ParsersModule.scala
+++ b/src/main/scala/org/spartanz/parserz/ParsersModule.scala
@@ -11,10 +11,13 @@ trait ParsersModule {
     import Grammar._
 
     final def map[B](to: A => B, from: B => A): Grammar[SI, SO, E, B] =
-      Grammar.Map[SI, SO, E, A, B](self, a => Right(to(a)), b => Right(from(b)))
+      Map[SI, SO, E, A, B](self, a => Right(to(a)), b => Right(from(b)))
+
+    final def mapOptional[E1 >: E, B](e: E1)(to: A => Option[B], from: B => Option[A]): Grammar[SI, SO, E1, B] =
+      Map[SI, SO, E1, A, B](self, asEither(e)(to), asEither(e)(from))
 
     final def mapPartial[E1 >: E, B](e: E1)(to: A =?> B, from: B =?> A): Grammar[SI, SO, E1, B] =
-      Grammar.Map[SI, SO, E1, A, B](self, asEither(e)(to.lift), asEither(e)(from.lift))
+      Map[SI, SO, E1, A, B](self, asEither(e)(to.lift), asEither(e)(from.lift))
 
     final def filter[E1 >: E](e: E1)(f: A => Boolean): Grammar[SI, SO, E1, A] =
       mapPartial[E1, A](e)({ case a if f(a) => a }, { case a if f(a) => a })
@@ -47,6 +50,7 @@ trait ParsersModule {
     private[parserz] case class Unit0() extends Grammar[Any, Nothing, Nothing, Unit]
     private[parserz] case class Consume0[SI, SO, E, A](to: Input => E \/ (Input, A), from: ((Input, A)) => E \/ Input) extends Grammar[Any, Nothing, E, A]
     private[parserz] case class Consume[SI, SO, E, A](to: (SI, Input) => (SO, E \/ (Input, A)), from: (SI, (Input, A)) => (SO, E \/ Input)) extends Grammar[SI, SO, E, A]
+    private[parserz] case class Delay[SI, SO, E, A](delayed: () => Grammar[SI, SO, E, A]) extends Grammar[SI, SO, E, A]
     private[parserz] case class Tag[SI, SO, E, A](value: Grammar[SI, SO, E, A], tag: String) extends Grammar[SI, SO, E, A]
     private[parserz] case class Map[SI, SO, E, A, B](value: Grammar[SI, SO, E, A], to: A => E \/ B, from: B => E \/ A) extends Grammar[SI, SO, E, B]
     private[parserz] case class Zip[SI, SO, E, A, B](left: Grammar[SI, SO, E, A], right: Grammar[SI, SO, E, B]) extends Grammar[SI, SO, E, A /\ B]
@@ -71,6 +75,13 @@ trait ParsersModule {
 
     final def consumeOptional0[E, A](e: E)(to: Input => Option[(Input, A)], from: ((Input, A)) => Option[Input]): Grammar[Any, Nothing, E, A] =
       consume0(asEither(e)(to), asEither(e)(from))
+
+    final def delay[SI, SO, E, A](g: => Grammar[SI, SO, E, A]): Grammar[SI, SO, E, A] =
+      Delay(() => g)
+
+    implicit final class ToGrammarOps(self: String) {
+      def @@ [SI, SO, E, A](g: Grammar[SI, SO, E, A]): Grammar[SI, SO, E, A] = g @@ self
+    }
   }
 
   final def parser[S, E, A](grammar: Grammar[S, S, E, A]): (S, Input) => (S, E \/ (Input, A)) = {
@@ -79,6 +90,7 @@ trait ParsersModule {
       case Grammar.Consume0(to, _)      => (s: S, i: Input) => (s, to(i))
       case Grammar.Consume(to, _)       => (s: S, i: Input) => to(s, i)
       case Grammar.Tag(value, _)        => (s: S, i: Input) => parser(value)(s, i)
+      case Grammar.Delay(delayed)       => (s: S, i: Input) => parser(delayed())(s, i)
 
       case Grammar.Map(value, to, _)    =>
         (s: S, i: Input) => {
@@ -91,7 +103,8 @@ trait ParsersModule {
           val ll = left.asInstanceOf[Grammar[Any, Any, E, Any]]
           val rr = right.asInstanceOf[Grammar[Any, Any, E, Any]]
           val res = parser(ll)(s, i) match {
-            case (s1, Left(e))        => (s1, Left(e))
+            case (s1, Left(e))        =>
+              (s1, Left(e))
             case (s1, Right((i1, a))) =>
               val (s2, res2) = parser(rr)(s1, i1)
               (s2, res2.map { case (i2, b) => (i2, (a, b)) })
@@ -99,24 +112,49 @@ trait ParsersModule {
           res.asInstanceOf[(Nothing, E \/ (Input, (Any, Any)))]
         }
 
-      case Grammar.Alt(left, right)     => println(left.toString + right.toString); ???
+      case Grammar.Alt(left, right)     =>
+        (s: S, i: Input) => {
+          val ll = left.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val rr = right.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val res = parser(ll)(s, i) match {
+            case (s1, Left(_))        =>
+              val (s2, res2) = parser(rr)(s1, i)
+              (s2, res2.map { case (i2, b) => (i2, Right(b)) })
+            case (s1, Right((i1, a))) =>
+              (s1, Right((i1, Left(a))))
+          }
+          res.asInstanceOf[(Nothing, E \/ (Input, Any \/ Any))]
+        }
 
       case Grammar.Rep(value)           =>
         (s: S, i: Input) => {
           val vv = value.asInstanceOf[Grammar[Any, Any, E, Any]]
-          @tailrec
-          def f(s: S, i: Input, as: List[Any]): (S, Input, List[Any]) =
-            parser(vv)(s, i) match {
-              case (_, Left(_))         => (s, i, as)
-              case (s1, Right((i1, a))) => f(s1.asInstanceOf[S], i1, a :: as)
-            }
-          val (s1, i1, as) = f(s, i, Nil)
+          val (s1, i1, as) = repeatParse(vv)(s, i, Nil)
           (s1, Right((i1, as.reverse))).asInstanceOf[(Nothing, E \/ (Input, List[Any]))]
         }
 
-      case Grammar.Rep1(value)          => println(value); ???
+      case Grammar.Rep1(value)       =>
+        (s: S, i: Input) => {
+          val vv = value.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val res = parser(vv)(s, i) match {
+            case (s1, Left(e))         =>
+              (s1, Left(e))
+            case (s1, Right((i1, a1))) =>
+              val (s2, i2, as) = repeatParse(vv)(s1, i1, Nil)
+              (s2, Right((i2, ::(a1, as))))
+          }
+          res.asInstanceOf[(Nothing, E \/ (Input, ::[Any]))]
+        }
     }
   }
+
+  @tailrec
+  private def repeatParse[S, E, A](g: Grammar[S, S, E, A])(s: S, i: Input, as: List[A]): (S, Input, List[A]) =
+    parser(g)(s, i) match {
+      case (s1, Left(_))        => (s1, i, as)
+      case (s1, Right((i1, a))) => repeatParse(g)(s1, i1, a :: as)
+    }
+
 
   final def printer[S, E, A](grammar: Grammar[S, S, E, A]): (S, (Input, A)) => (S, E \/ Input) =
     grammar match {
@@ -124,10 +162,12 @@ trait ParsersModule {
       case Grammar.Consume0(_, from)    => (s: S, a: (Input, A)) => (s, from(a))
       case Grammar.Consume(_, from)     => (s: S, a: (Input, A)) => from(s, a)
       case Grammar.Tag(value, _)        => (s: S, a: (Input, A)) => printer(value)(s, a)
+      case Grammar.Delay(delayed)       => (s: S, a: (Input, A)) => printer(delayed())(s, a)
 
-      case Grammar.Map(value, _, from) =>
-        (s: S, a: (Input, A)) =>
+      case Grammar.Map(value, _, from)  =>
+        (s: S, a: (Input, A)) => {
           from(a._2).fold(e => s -> Left(e), b => printer(value)(s, (a._1, b)))
+        }
 
       case Grammar.Zip(left, right)     =>
         // todo: use existential A and B here?
@@ -142,20 +182,38 @@ trait ParsersModule {
           res2.asInstanceOf[(Nothing, E \/ Input)]
         }
 
-      case Grammar.Alt(left, right)     => println(left + right.toString); ???
-
-      case Grammar.Rep(value)           =>
-        (s: S, a: (Input, List[Any])) => {
-          val vv = value.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val res = a._2.foldLeft[(Any, E \/ Input)]((s, Right(a._1))) {
-            case ((s0, Left(e)), _) => s0 -> Left(e)
-            case ((s0, Right(i0)), a0) => printer(vv)(s0, (i0, a0))
+      case Grammar.Alt(left, right)     =>
+        (s: S, a: (Input, Any \/ Any)) => {
+          val ll = left.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val rr = right.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val res = a._2 match {
+            case Left(v)  => printer(ll)(s, (a._1, v))
+            case Right(v) => printer(rr)(s, (a._1, v))
           }
           res.asInstanceOf[(Nothing, E \/ Input)]
         }
 
-      case Grammar.Rep1(value)          => println(value); ???
+      case Grammar.Rep(value)           =>
+        (s: S, a: (Input, List[Any])) => {
+          val vv = value.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val res = repeatPrint(vv)(s, a._1, a._2)
+          res.asInstanceOf[(Nothing, E \/ Input)]
+        }
+
+      case Grammar.Rep1(value)          =>
+        (s: S, a: (Input, ::[Any])) => {
+          val vv = value.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val res = repeatPrint(vv)(s, a._1, a._2)
+          res.asInstanceOf[(Nothing, E \/ Input)]
+        }
     }
+
+  private def repeatPrint[S, E, A](g: Grammar[S, S, E, A])(s: S, i: Input, as: List[A]): (S, E \/ Input) =
+    as.foldLeft[(S, E \/ Input)](s -> Right(i)) {
+      case ((s0, Left(e)), _)    => s0 -> Left(e)
+      case ((s0, Right(i0)), a0) => printer(g)(s0, (i0, a0))
+    }
+
 
   final def bnf[SI, SO, E, A](grammar: Grammar[SI, SO, E, A]): String = ???
 }

--- a/src/main/scala/org/spartanz/parserz/ParsersModule.scala
+++ b/src/main/scala/org/spartanz/parserz/ParsersModule.scala
@@ -215,7 +215,6 @@ trait ParsersModule {
 
   private def repeatPrint[S, E, A](g: Grammar[S, S, E, A])(s: S, i: Input, as: List[A]): (S, E \/ Input) =
     as.foldLeft[(S, E \/ Input)](s -> Right(i)) {
-      case ((s0, Left(e)), _)    => s0 -> Left(e)
       case ((s0, Right(i0)), a0) => printer(g)(s0, (i0, a0))
     }
 

--- a/src/main/scala/org/spartanz/parserz/ParsersModule.scala
+++ b/src/main/scala/org/spartanz/parserz/ParsersModule.scala
@@ -1,0 +1,165 @@
+package org.spartanz.parserz
+
+import scala.annotation.tailrec
+
+trait ParsersModule {
+  type Input
+
+  sealed abstract class Grammar[-SI, +SO, +E, A] {
+    self =>
+
+    import Grammar._
+
+    final def map[B](to: A => B, from: B => A): Grammar[SI, SO, E, B] =
+      Grammar.Map[SI, SO, E, A, B](self, a => Right(to(a)), b => Right(from(b)))
+
+    final def mapPartial[E1 >: E, B](e: E1)(to: A =?> B, from: B =?> A): Grammar[SI, SO, E1, B] =
+      Grammar.Map[SI, SO, E1, A, B](self, asEither(e)(to.lift), asEither(e)(from.lift))
+
+    final def filter[E1 >: E](e: E1)(f: A => Boolean): Grammar[SI, SO, E1, A] =
+      mapPartial[E1, A](e)({ case a if f(a) => a }, { case a if f(a) => a })
+
+    final def zip[SI1 <: SI, SO1 >: SO, E1 >: E, B](that: Grammar[SI1, SO1, E1, B]): Grammar[SI1, SO1, E1, A /\ B] =
+      Zip(self, that)
+
+    final def alt[SI1 <: SI, SO1 >: SO, E1 >: E, B](that: Grammar[SI1, SO1, E1, B]): Grammar[SI1, SO1, E1, A \/ B] =
+      Alt(self, that)
+
+    final def ∘ [B](to: A => B, from: B => A): Grammar[SI, SO, E, B] = map(to, from)
+
+    final def ~ [SI1 <: SI, SO1 >: SO, E1 >: E, B](that: Grammar[SI1, SO1, E1, B]): Grammar[SI1, SO1, E1, A /\ B] = self zip that
+
+    final def | [SI1 <: SI, SO1 >: SO, E1 >: E, B](that: Grammar[SI1, SO1, E1, B]): Grammar[SI1, SO1, E1, A \/ B] = self alt that
+
+    final def rep: Grammar[SI, SO, E, List[A]] = Rep(self)
+
+    final def rep1: Grammar[SI, SO, E, ::[A]] = Rep1(self)
+
+    final def @@(tag: String): Grammar[SI, SO, E, A] = Tag(self, tag)
+
+    final def tag(tag: String): Grammar[SI, SO, E, A] = self @@ tag
+  }
+
+  object Grammar {
+    private def asEither[E, A, B](e: E)(f: A => Option[B]): A => E \/ B =
+      f(_).map(Right(_)).getOrElse(Left(e))
+
+    private[parserz] case class Unit0() extends Grammar[Any, Nothing, Nothing, Unit]
+    private[parserz] case class Consume0[SI, SO, E, A](to: Input => E \/ (Input, A), from: ((Input, A)) => E \/ Input) extends Grammar[Any, Nothing, E, A]
+    private[parserz] case class Consume[SI, SO, E, A](to: (SI, Input) => (SO, E \/ (Input, A)), from: (SI, (Input, A)) => (SO, E \/ Input)) extends Grammar[SI, SO, E, A]
+    private[parserz] case class Tag[SI, SO, E, A](value: Grammar[SI, SO, E, A], tag: String) extends Grammar[SI, SO, E, A]
+    private[parserz] case class Map[SI, SO, E, A, B](value: Grammar[SI, SO, E, A], to: A => E \/ B, from: B => E \/ A) extends Grammar[SI, SO, E, B]
+    private[parserz] case class Zip[SI, SO, E, A, B](left: Grammar[SI, SO, E, A], right: Grammar[SI, SO, E, B]) extends Grammar[SI, SO, E, A /\ B]
+    private[parserz] case class Alt[SI, SO, E, A, B](left: Grammar[SI, SO, E, A], right: Grammar[SI, SO, E, B]) extends Grammar[SI, SO, E, A \/ B]
+    private[parserz] case class Rep[SI, SO, E, A](value: Grammar[SI, SO, E, A]) extends Grammar[SI, SO, E, List[A]]
+    private[parserz] case class Rep1[SI, SO, E, A](value: Grammar[SI, SO, E, A]) extends Grammar[SI, SO, E, ::[A]]
+
+    final val unit: Grammar[Any, Nothing, Nothing, Unit] =
+      Unit0()
+
+    final def succeed[A](a: A): Grammar[Any, Nothing, Nothing, A] =
+      unit.map[A](_ => a, _ => ())
+
+    final def fail[E, A](e: E): Grammar[Any, Nothing, E, A] =
+      unit.mapPartial(e)(PartialFunction.empty, PartialFunction.empty)
+
+    final def consume[SI, SO, E, A](to: (SI, Input) => (SO, E \/ (Input, A)), from: (SI, (Input, A)) => (SO, E \/ Input)): Grammar[SI, SO, E, A] =
+      Consume(to, from)
+
+    final def consume0[A, E](to: Input => E \/ (Input, A), from: ((Input, A)) => E \/ Input): Grammar[Any, Nothing, E, A] =
+      Consume0(to, from)
+
+    final def consumeOptional0[E, A](e: E)(to: Input => Option[(Input, A)], from: ((Input, A)) => Option[Input]): Grammar[Any, Nothing, E, A] =
+      consume0(asEither(e)(to), asEither(e)(from))
+  }
+
+  final def parser[S, E, A](grammar: Grammar[S, S, E, A]): (S, Input) => (S, E \/ (Input, A)) = {
+    grammar match {
+      case Grammar.Unit0()              => (s: S, i: Input) => (s, Right((i, ())))
+      case Grammar.Consume0(to, _)      => (s: S, i: Input) => (s, to(i))
+      case Grammar.Consume(to, _)       => (s: S, i: Input) => to(s, i)
+      case Grammar.Tag(value, _)        => (s: S, i: Input) => parser(value)(s, i)
+
+      case Grammar.Map(value, to, _)    =>
+        (s: S, i: Input) => {
+          val (s1, res1) = parser(value)(s, i)
+          (s1, res1.flatMap { case (i1, a) => to(a).map(i1 -> _) })
+        }
+
+      case Grammar.Zip(left, right)     =>
+        (s: S, i: Input) => {
+          val ll = left.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val rr = right.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val res = parser(ll)(s, i) match {
+            case (s1, Left(e))        => (s1, Left(e))
+            case (s1, Right((i1, a))) =>
+              val (s2, res2) = parser(rr)(s1, i1)
+              (s2, res2.map { case (i2, b) => (i2, (a, b)) })
+            }
+          res.asInstanceOf[(Nothing, E \/ (Input, (Any, Any)))]
+        }
+
+      case Grammar.Alt(left, right)     => println(left.toString + right.toString); ???
+
+      case Grammar.Rep(value)           =>
+        (s: S, i: Input) => {
+          val vv = value.asInstanceOf[Grammar[Any, Any, E, Any]]
+          @tailrec
+          def f(s: S, i: Input, as: List[Any]): (S, Input, List[Any]) =
+            parser(vv)(s, i) match {
+              case (_, Left(_))         => (s, i, as)
+              case (s1, Right((i1, a))) => f(s1.asInstanceOf[S], i1, a :: as)
+            }
+          val (s1, i1, as) = f(s, i, Nil)
+          (s1, Right((i1, as.reverse))).asInstanceOf[(Nothing, E \/ (Input, List[Any]))]
+        }
+
+      case Grammar.Rep1(value)          => println(value); ???
+    }
+  }
+
+  final def printer[S, E, A](grammar: Grammar[S, S, E, A]): (S, (Input, A)) => (S, E \/ Input) =
+    grammar match {
+      case Grammar.Unit0()              => (s: S, a: (Input, A)) => (s, Right(a._1))
+      case Grammar.Consume0(_, from)    => (s: S, a: (Input, A)) => (s, from(a))
+      case Grammar.Consume(_, from)     => (s: S, a: (Input, A)) => from(s, a)
+      case Grammar.Tag(value, _)        => (s: S, a: (Input, A)) => printer(value)(s, a)
+
+      case Grammar.Map(value, _, from) =>
+        (s: S, a: (Input, A)) =>
+          from(a._2).fold(e => s -> Left(e), b => printer(value)(s, (a._1, b)))
+
+      case Grammar.Zip(left, right)     =>
+        // todo: use existential A and B here?
+        (s: S, a: (Input, (Any, Any))) => {
+          val ll = left.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val rr = right.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val (s1, res1) = printer(ll)(s, (a._1, a._2._1)).asInstanceOf[(S, E \/ Input)]
+          val res2: (S, E \/ Input) = res1 match {
+            case Left(e) => (s1, Left(e))
+            case Right(i1) => printer(rr)(s1, (i1, a._2._2)).asInstanceOf[(S, E \/ Input)]
+          }
+          res2.asInstanceOf[(Nothing, E \/ Input)]
+        }
+
+      case Grammar.Alt(left, right)     => println(left + right.toString); ???
+
+      case Grammar.Rep(value)           =>
+        (s: S, a: (Input, List[Any])) => {
+          val vv = value.asInstanceOf[Grammar[Any, Any, E, Any]]
+          val res = a._2.foldLeft[(Any, E \/ Input)]((s, Right(a._1))) {
+            case ((s0, Left(e)), _) => s0 -> Left(e)
+            case ((s0, Right(i0)), a0) => printer(vv)(s0, (i0, a0))
+          }
+          res.asInstanceOf[(Nothing, E \/ Input)]
+        }
+
+      case Grammar.Rep1(value)          => println(value); ???
+    }
+
+  final def bnf[SI, SO, E, A](grammar: Grammar[SI, SO, E, A]): String = ???
+}
+
+object ParsersModule {
+
+}

--- a/src/main/scala/org/spartanz/parserz/ParsersModule.scala
+++ b/src/main/scala/org/spartanz/parserz/ParsersModule.scala
@@ -72,7 +72,7 @@ trait ParsersModule {
     ): Grammar[SI, SO, E, A] =
       Consume(to, from)
 
-    final def consume0[A, E](to: Input => E \/ (Input, A), from: ((Input, A)) => E \/ Input): Grammar[Any, Nothing, E, A] =
+    final def consume0[E, A](to: Input => E \/ (Input, A), from: ((Input, A)) => E \/ Input): Grammar[Any, Nothing, E, A] =
       Consume0(to, from)
 
     final def consumeOptional0[E, A](

--- a/src/main/scala/org/spartanz/parserz/ParsersModule.scala
+++ b/src/main/scala/org/spartanz/parserz/ParsersModule.scala
@@ -1,5 +1,7 @@
 package org.spartanz.parserz
 
+import com.github.ghik.silencer.silent
+
 import scala.annotation.tailrec
 
 trait ParsersModule {
@@ -51,10 +53,22 @@ trait ParsersModule {
     private[parserz] case class Delay[SI, SO, E, A](delayed: () => Grammar[SI, SO, E, A]) extends Grammar[SI, SO, E, A]
     private[parserz] case class Tag[SI, SO, E, A](value: Grammar[SI, SO, E, A], tag: String) extends Grammar[SI, SO, E, A]
     private[parserz] case class Map[SI, SO, E, A, B](value: Grammar[SI, SO, E, A], to: A => E \/ B, from: B => E \/ A) extends Grammar[SI, SO, E, B]
-    private[parserz] case class Zip[SI, SO, E, A, B](left: Grammar[SI, SO, E, A], right: Grammar[SI, SO, E, B]) extends Grammar[SI, SO, E, A /\ B]
-    private[parserz] case class Alt[SI, SO, E, A, B](left: Grammar[SI, SO, E, A], right: Grammar[SI, SO, E, B]) extends Grammar[SI, SO, E, A \/ B]
-    private[parserz] case class Rep[SI, SO, E, A](value: Grammar[SI, SO, E, A]) extends Grammar[SI, SO, E, List[A]]
-    private[parserz] case class Rep1[SI, SO, E, A](value: Grammar[SI, SO, E, A]) extends Grammar[SI, SO, E, ::[A]]
+
+    private[parserz] case class Zip[SI, SO, E, A, B, Z](left: Grammar[SI, SO, E, A], right: Grammar[SI, SO, E, B])(
+      @silent implicit val ev: Z =:= (A /\ B)
+    ) extends Grammar[SI, SO, E, Z]
+
+    private[parserz] case class Alt[SI, SO, E, A, B, Z](left: Grammar[SI, SO, E, A], right: Grammar[SI, SO, E, B])(
+      @silent implicit val ev: Z =:= (A \/ B)
+    ) extends Grammar[SI, SO, E, Z]
+
+    private[parserz] case class Rep[SI, SO, E, A, Z](value: Grammar[SI, SO, E, A])(
+      @silent implicit val ev: Z =:= List[A]
+    ) extends Grammar[SI, SO, E, Z]
+
+    private[parserz] case class Rep1[SI, SO, E, A, Z](value: Grammar[SI, SO, E, A])(
+      @silent implicit val ev: Z =:= ::[A]
+    ) extends Grammar[SI, SO, E, Z]
     // format: on
 
     final val unit: Grammar[Any, Nothing, Nothing, Unit] =
@@ -106,52 +120,40 @@ trait ParsersModule {
         }
 
       case Grammar.Zip(left, right) =>
-        (s: S, i: Input) => {
-          val ll = left.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val rr = right.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val res = parser(ll)(s, i) match {
+        (s: S, i: Input) =>
+          parser(left)(s, i) match {
             case (s1, Left(e)) =>
               (s1, Left(e))
             case (s1, Right((i1, a))) =>
-              val (s2, res2) = parser(rr)(s1, i1)
-              (s2, res2.map { case (i2, b) => (i2, (a, b)) })
+              val (s2, res2) = parser(right)(s1, i1)
+              (s2, res2.map { case (i2, b) => (i2, (a, b).asInstanceOf[A]) })
           }
-          res.asInstanceOf[(Nothing, E \/ (Input, (Any, Any)))]
-        }
 
       case Grammar.Alt(left, right) =>
-        (s: S, i: Input) => {
-          val ll = left.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val rr = right.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val res = parser(ll)(s, i) match {
+        (s: S, i: Input) =>
+          parser(left)(s, i) match {
             case (s1, Left(_)) =>
-              val (s2, res2) = parser(rr)(s1, i)
-              (s2, res2.map { case (i2, b) => (i2, Right(b)) })
+              val (s2, res2) = parser(right)(s1, i)
+              (s2, res2.map { case (i2, b) => (i2, Right(b).asInstanceOf[A]) })
             case (s1, Right((i1, a))) =>
-              (s1, Right((i1, Left(a))))
+              (s1, Right((i1, Left(a).asInstanceOf[A])))
           }
-          res.asInstanceOf[(Nothing, E \/ (Input, Any \/ Any))]
-        }
 
       case Grammar.Rep(value) =>
         (s: S, i: Input) => {
-          val vv           = value.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val (s1, i1, as) = repeatParse(vv)(s, i, Nil)
-          (s1, Right((i1, as.reverse))).asInstanceOf[(Nothing, E \/ (Input, List[Any]))]
+          val (s1, i1, as) = repeatParse(value)(s, i, Nil)
+          (s1, Right((i1, as.reverse.asInstanceOf[A])))
         }
 
       case Grammar.Rep1(value) =>
-        (s: S, i: Input) => {
-          val vv = value.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val res = parser(vv)(s, i) match {
+        (s: S, i: Input) =>
+          parser(value)(s, i) match {
             case (s1, Left(e)) =>
               (s1, Left(e))
             case (s1, Right((i1, a1))) =>
-              val (s2, i2, as) = repeatParse(vv)(s1, i1, Nil)
-              (s2, Right((i2, ::(a1, as))))
+              val (s2, i2, as) = repeatParse(value)(s1, i1, Nil)
+              (s2, Right((i2, ::(a1, as).asInstanceOf[A])))
           }
-          res.asInstanceOf[(Nothing, E \/ (Input, ::[Any]))]
-        }
     }
 
   @tailrec
@@ -175,41 +177,34 @@ trait ParsersModule {
         }
 
       case Grammar.Zip(left, right) =>
-        // todo: use existential A and B here?
-        (s: S, a: (Input, (Any, Any))) => {
-          val ll         = left.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val rr         = right.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val (s1, res1) = printer(ll)(s, (a._1, a._2._1)).asInstanceOf[(S, E \/ Input)]
-          val res2: (S, E \/ Input) = res1 match {
+        (s: S, a: (Input, A)) => {
+          val (i, (a1, a2)) = (a._1, a._2.asInstanceOf[A /\ A])
+          val (s1, res1)    = printer(left)(s, (i, a1))
+          res1 match {
             case Left(e)   => (s1, Left(e))
-            case Right(i1) => printer(rr)(s1, (i1, a._2._2)).asInstanceOf[(S, E \/ Input)]
+            case Right(i1) => printer(right)(s1, (i1, a2))
           }
-          res2.asInstanceOf[(Nothing, E \/ Input)]
         }
 
       case Grammar.Alt(left, right) =>
-        (s: S, a: (Input, Any \/ Any)) => {
-          val ll = left.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val rr = right.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val res = a._2 match {
-            case Left(v)  => printer(ll)(s, (a._1, v))
-            case Right(v) => printer(rr)(s, (a._1, v))
+        (s: S, a: (Input, A)) => {
+          val (i, aa) = (a._1, a._2.asInstanceOf[A \/ A])
+          aa match {
+            case Left(v)  => printer(left)(s, (i, v))
+            case Right(v) => printer(right)(s, (i, v))
           }
-          res.asInstanceOf[(Nothing, E \/ Input)]
         }
 
       case Grammar.Rep(value) =>
-        (s: S, a: (Input, List[Any])) => {
-          val vv  = value.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val res = repeatPrint(vv)(s, a._1, a._2)
-          res.asInstanceOf[(Nothing, E \/ Input)]
+        (s: S, a: (Input, A)) => {
+          val (i, la) = (a._1, a._2.asInstanceOf[List[A]])
+          repeatPrint(value)(s, i, la)
         }
 
       case Grammar.Rep1(value) =>
-        (s: S, a: (Input, ::[Any])) => {
-          val vv  = value.asInstanceOf[Grammar[Any, Any, E, Any]]
-          val res = repeatPrint(vv)(s, a._1, a._2)
-          res.asInstanceOf[(Nothing, E \/ Input)]
+        (s: S, a: (Input, A)) => {
+          val (i, la) = (a._1, a._2.asInstanceOf[::[A]])
+          repeatPrint(value)(s, i, la)
         }
     }
 

--- a/src/main/scala/org/spartanz/parserz/package.scala
+++ b/src/main/scala/org/spartanz/parserz/package.scala
@@ -4,5 +4,7 @@ package object parserz {
 
   type ->[A, B] = (A, B)
   type /\[A, B] = (A, B)
-  type \/[A, B] = Either[A, B]
+  type \/[+A, +B] = Either[A, B]
+
+  type =?>[-A, +B] = PartialFunction[A, B]
 }

--- a/src/main/scala/org/spartanz/parserz/package.scala
+++ b/src/main/scala/org/spartanz/parserz/package.scala
@@ -2,8 +2,8 @@ package org.spartanz
 
 package object parserz {
 
-  type ->[A, B] = (A, B)
-  type /\[A, B] = (A, B)
+  type ->[A, B]   = (A, B)
+  type /\[A, B]   = (A, B)
   type \/[+A, +B] = Either[A, B]
 
   type =?>[-A, +B] = PartialFunction[A, B]

--- a/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
+++ b/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
@@ -154,14 +154,27 @@ class ClassicExampleV2Spec extends Specification {
   }
 
   "Docs" should {
+    "be available for all grammars 0" in {
+      Example.Parser.bnf(Example.Parser.Grammar.unit.tag("const")) must_=== Nil
+    }
     "be available for all grammars 1" in {
+      Example.Parser.bnf(
+        Example.Parser.Grammar
+          .consume[Int, Int, String, Any](
+            (s, _) => (s, Left("a test")),
+            (s, _) => (s, Left("a test"))
+          )
+          .tag("failed")
+      ) must_=== Nil
+    }
+    "be available for all grammars 2" in {
       Example.Parser.bnf(Example.integer).mkString("\n", "\n", "\n") must_===
         """
           |<digit> ::= <char>
           |<integer> ::= NEL(<digit>)
           |""".stripMargin
     }
-    "be available for all grammars 2" in {
+    "be available for all grammars 3" in {
       Example.Parser.bnf(Example.addition).mkString("\n", "\n", "\n") must_===
         """
           |<digit> ::= <char>

--- a/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
+++ b/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
@@ -36,13 +36,15 @@ class ClassicExampleV2Spec extends Specification {
       { case (s, c) => Some(s + c.toString) }
     )
 
-    val digit: Grammar[Any, Nothing, E, Char]    = "digit" @@ char.filter("expected: digit")(_.isDigit)
-    val paren1: Grammar[Any, Nothing, E, Char]   = "(" @@ char.filter("expected: open paren")(_ == '(')
-    val paren2: Grammar[Any, Nothing, E, Char]   = ")" @@ char.filter("expected: close paren")(_ == ')')
+    val digit: Grammar[Any, Nothing, E, Char]  = "digit" @@ char.filter("expected: digit")(_.isDigit)
+    val paren1: Grammar[Any, Nothing, E, Char] = "(" @@ char.filter("expected: open paren")(_ == '(')
+    val paren2: Grammar[Any, Nothing, E, Char] = ")" @@ char.filter("expected: close paren")(_ == ')')
+
     val plus: Grammar[Any, Nothing, E, Operator] = "+" @@ char.mapPartial("expected: '+'")(
       { case '+' => Add },
       { case Add => '+' }
     )
+
     val star: Grammar[Any, Nothing, E, Operator] = "*" @@ char.mapPartial("expected: '*'")(
       { case '*' => Mul },
       { case Mul => '*' }
@@ -50,7 +52,7 @@ class ClassicExampleV2Spec extends Specification {
 
     val integer: Grammar[Any, Nothing, E, Int] = "integer" @@ digit.rep1.map(
       chars => chars.mkString.toInt,
-      int   => { val chars = int.toString.toList; ::(chars.head, chars.tail) }
+      int => { val chars = int.toString.toList; ::(chars.head, chars.tail) }
     )
 
     val constant: Grammar[Any, Nothing, E, Expression] = "Constant" @@ integer.mapPartial("expected: Constant")(
@@ -89,18 +91,19 @@ class ClassicExampleV2Spec extends Specification {
       list.foldLeft(z) { case (e1, (op, e2)) => Operation(e1, op, e2) }
 
     @tailrec
-    private def unfold2(op: Operator)(acc: List[(Operator, Expression)])(e: Expression): Option[(Expression, List[(Operator, Expression)])] = e match {
-      case c @ Constant(_) => Some((c, acc))
-      case _ @ SubExpr(_) => None
+    private def unfold2(
+      op: Operator
+    )(acc: List[(Operator, Expression)])(e: Expression): Option[(Expression, List[(Operator, Expression)])] = e match {
+      case c @ Constant(_)                       => Some((c, acc))
+      case _ @SubExpr(_)                         => None
       case o @ Operation(_, op2, _) if op2 != op => Some((o, acc))
-      case _ @ Operation(e1, `op`, e2) => unfold2(op)((op, e2) :: acc)(e1)
+      case _ @Operation(e1, `op`, e2)            => unfold2(op)((op, e2) :: acc)(e1)
     }
 
 
-    val parser: (S, Input) => (S, E \/ (Input, Expression)) = Parser.parser[S, E, Expression](addition)
+    val parser: (S, Input) => (S, E \/ (Input, Expression))  = Parser.parser[S, E, Expression](addition)
     val printer: (S, (Input, Expression)) => (S, E \/ Input) = Parser.printer[S, E, Expression](addition)
   }
-
 
   import Syntax._
 

--- a/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
+++ b/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
@@ -29,7 +29,7 @@ class ClassicExampleV2Spec extends Specification {
     import Parser._
     import Syntax._
 
-    val char: Grammar[Any, Nothing, E, Char] = consumeOptional0("expected: char")(
+    val char: Grammar[Any, Nothing, E, Char] = "char" @@ consumeOptional0("expected: char")(
       s => s.headOption.map(s.drop(1) -> _),
       { case (s, c) => Some(s + c.toString) }
     )
@@ -151,5 +151,30 @@ class ClassicExampleV2Spec extends Specification {
   }
   "incorrect composition 3" in {
     print(SubExpr(Constant(1))) must_=== Left("expected: Constant")
+  }
+
+  "Docs" should {
+    "be available for all grammars 1" in {
+      Example.Parser.bnf(Example.integer).mkString("\n", "\n", "\n") must_===
+        """
+          |<digit> ::= <char>
+          |<integer> ::= NEL(<digit>)
+          |""".stripMargin
+    }
+    "be available for all grammars 2" in {
+      Example.Parser.bnf(Example.addition).mkString("\n", "\n", "\n") must_===
+        """
+          |<digit> ::= <char>
+          |<integer> ::= NEL(<digit>)
+          |<Constant> ::= <integer>
+          |<*> ::= <char>
+          |<(> ::= <char>
+          |<)> ::= <char>
+          |<Multiplier> ::= (<(> <Addition> <)> | <Constant>)
+          |<Multiplication> ::= <Constant> List(<*> <Multiplier>)
+          |<+> ::= <char>
+          |<Addition> ::= <Multiplication> List(<+> <Multiplication>)
+          |""".stripMargin
+    }
   }
 }

--- a/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
+++ b/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
@@ -43,9 +43,9 @@ class ClassicExampleV2Spec extends Specification {
       { case Add => '+' }
     )
 
-    val star: Grammar[Any, Nothing, E, Operator] = "*" @@ char.mapPartial("expected: '*'")(
-      { case '*' => Mul },
-      { case Mul => '*' }
+    val star: Grammar[Any, Nothing, E, Operator] = "*" @@ char.mapOptional("expected: '*'")(
+      { case '*' => Some(Mul); case _ => None },
+      { case Mul => Some('*'); case _ => None }
     )
 
     val integer: Grammar[Any, Nothing, E, Int] = "integer" @@ digit.rep1.map(

--- a/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
+++ b/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
@@ -1,0 +1,173 @@
+package org.spartanz.parserz
+
+import org.specs2.matcher.MatchResult
+import org.specs2.mutable.Specification
+
+import scala.annotation.tailrec
+
+class ClassicExampleV2Spec extends Specification {
+
+  object Syntax {
+    sealed trait Expression
+    case class Constant(value: Int)                                    extends Expression
+    case class Operation(e1: Expression, op: Operator, e2: Expression) extends Expression
+    case class SubExpr(e: Expression)                                  extends Expression
+
+    sealed trait Operator
+    case object Add extends Operator
+    case object Mul extends Operator
+  }
+
+  object Example {
+
+    object Parser extends ParsersModule {
+      override type Input = String
+    }
+
+    type S = Unit
+    type E = String
+
+    import Syntax._
+    import Parser._
+    import Parser.Grammar._
+
+    val char: Grammar[Any, Nothing, E, Char] = consumeOptional0[E, Char]("expected: char")(
+      s => s.headOption.map(s.drop(1) -> _),
+      { case (s, c) => Some(s + c.toString) }
+    )
+
+    val digit: Grammar[Any, Nothing, E, Char]    = "digit" @@ char.filter("expected: digit")(_.isDigit)
+    val paren1: Grammar[Any, Nothing, E, Char]   = "(" @@ char.filter("expected: open paren")(_ == '(')
+    val paren2: Grammar[Any, Nothing, E, Char]   = ")" @@ char.filter("expected: close paren")(_ == ')')
+    val plus: Grammar[Any, Nothing, E, Operator] = "+" @@ char.mapPartial("expected: '+'")(
+      { case '+' => Add },
+      { case Add => '+' }
+    )
+    val star: Grammar[Any, Nothing, E, Operator] = "*" @@ char.mapPartial("expected: '*'")(
+      { case '*' => Mul },
+      { case Mul => '*' }
+    )
+
+    val integer: Grammar[Any, Nothing, E, Int] = "integer" @@ digit.rep1.map(
+      chars => chars.mkString.toInt,
+      int   => { val chars = int.toString.toList; ::(chars.head, chars.tail) }
+    )
+
+    val constant: Grammar[Any, Nothing, E, Expression] = "Constant" @@ integer.mapPartial("expected: Constant")(
+      { case i           => Constant(i) },
+      { case Constant(i) => i }
+    )
+
+    val multiplier: Grammar[Any, Nothing, E, Expression] = "Multiplier" @@ ((paren1 ~ addition ~ paren2) | constant).map({
+      case Left(((_, exp), _)) => SubExpr(exp)
+      case Right(exp)          => exp
+    }, {
+      case SubExpr(exp) => Left((('(', exp), ')'))
+      case exp          => Right(exp)
+    })
+
+    val multiplication: Grammar[Any, Nothing, E, Expression] = "Multiplication" @@ {
+      (constant ~ (star ~ multiplier).rep)
+        .mapOptional("wrong order of ops (hm...)")(
+          arg => Some((fold2 _).tupled(arg)),
+          unfold2(Mul)(Nil)
+        )
+    }
+
+    lazy val addition: Grammar[Any, Nothing, E, Expression] = "Addition" @@ delay {
+      (multiplication ~ (plus ~ multiplication).rep)
+        .mapOptional("wrong order of ops (hmm...)")(
+          arg => Some((fold2 _).tupled(arg)),
+          unfold2(Add)(Nil)
+        )
+    }
+
+
+    // todo: generalize fold/unfold
+
+    private def fold2(z: Expression, list: List[(Operator, Expression)]): Expression =
+      list.foldLeft(z) { case (e1, (op, e2)) => Operation(e1, op, e2) }
+
+    @tailrec
+    private def unfold2(op: Operator)(acc: List[(Operator, Expression)])(e: Expression): Option[(Expression, List[(Operator, Expression)])] = e match {
+      case c @ Constant(_) => Some((c, acc))
+      case _ @ SubExpr(_) => None
+      case o @ Operation(_, op2, _) if op2 != op => Some((o, acc))
+      case _ @ Operation(e1, `op`, e2) => unfold2(op)((op, e2) :: acc)(e1)
+    }
+
+
+    val parser: (S, Input) => (S, E \/ (Input, Expression)) = Parser.parser[S, E, Expression](addition)
+    val printer: (S, (Input, Expression)) => (S, E \/ Input) = Parser.printer[S, E, Expression](addition)
+  }
+
+
+  import Syntax._
+
+  private def parse(s: String)  = Example.parser((), s)._2
+  private def parse0(s: String) = parse(s).right.get._2
+
+  private def print(e: Expression)  = Example.printer((), ("", e))._2
+  private def print0(e: Expression) = print(e).right.get
+
+  private def loop0(s: String, e: Expression): MatchResult[Any] = {
+    val parsed  = parse0(s)
+    val printed = print0(parsed)
+    (parsed must_=== e).and(printed must_=== s)
+  }
+
+  "empty" in {
+    parse("") must_=== Left("expected: char")
+  }
+  "single letter" in {
+    parse("A") must_=== Left("expected: digit")
+  }
+  "single digit" in {
+    loop0("1", Constant(1))
+  }
+  "several digits" in {
+    loop0("12", Constant(12))
+  }
+  "just the plus" in {
+    parse("+") must_=== Left("expected: digit")
+  }
+  "sum of two" in {
+    loop0("1+2", Operation(Constant(1), Add, Constant(2)))
+  }
+  "sum of three" in {
+    loop0("1+2+3", Operation(Operation(Constant(1), Add, Constant(2)), Add, Constant(3)))
+  }
+  "parse sum until it cannot anymore" in {
+    parse("1+2++3") must_=== Right(("++3", Operation(Constant(1), Add, Constant(2))))
+  }
+  "parse mul until it cannot anymore" in {
+    parse("1*2**3") must_=== Right(("**3", Operation(Constant(1), Mul, Constant(2))))
+  }
+  "mul of two" in {
+    loop0("1*2", Operation(Constant(1), Mul, Constant(2)))
+  }
+  "mul of three" in {
+    loop0("1*2*3", Operation(Operation(Constant(1), Mul, Constant(2)), Mul, Constant(3)))
+  }
+  "mul of two with parens" in {
+    loop0("1*(2)", Operation(Constant(1), Mul, SubExpr(Constant(2))))
+  }
+  "mix of three" in {
+    loop0("12*34+56", Operation(Operation(Constant(12), Mul, Constant(34)), Add, Constant(56)))
+  }
+  "mix of four (implicit precedence)" in {
+    loop0("12+34*56+78", Operation(Operation(Constant(12), Add, Operation(Constant(34), Mul, Constant(56))), Add, Constant(78)))
+  }
+  "mix of four (explicit precedence)" in {
+    loop0("12+34*(56+78)", Operation(Constant(12), Add, Operation(Constant(34), Mul, SubExpr(Operation(Constant(56), Add, Constant(78))))))
+  }
+  "incorrect composition" in {
+    print(Operation(Constant(1), Add, Operation(Constant(2), Add, Constant(3)))) must_=== Left("expected: Constant")
+  }
+  "incorrect composition 2" in {
+    print(Operation(Constant(1), Add, SubExpr(Constant(2)))) must_=== Left("wrong order of ops (hm...)")
+  }
+  "incorrect composition 3" in {
+    print(SubExpr(Constant(1))) must_=== Left("wrong order of ops (hmm...)")
+  }
+}

--- a/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
+++ b/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
@@ -31,14 +31,14 @@ class ClassicExampleV2Spec extends Specification {
     import Parser._
     import Parser.Grammar._
 
-    val char: Grammar[Any, Nothing, E, Char] = consumeOptional0[E, Char]("expected: char")(
+    val char: Grammar[Any, Nothing, E, Char] = consumeOptional0("expected: char")(
       s => s.headOption.map(s.drop(1) -> _),
       { case (s, c) => Some(s + c.toString) }
     )
 
-    val digit: Grammar[Any, Nothing, E, Char]  = "digit" @@ char.filter("expected: digit")(_.isDigit)
-    val paren1: Grammar[Any, Nothing, E, Char] = "(" @@ char.filter("expected: open paren")(_ == '(')
-    val paren2: Grammar[Any, Nothing, E, Char] = ")" @@ char.filter("expected: close paren")(_ == ')')
+    val digit: Grammar[Any, Nothing, E, Char]  = char.filter("expected: digit")(_.isDigit).tag("digit")
+    val paren1: Grammar[Any, Nothing, E, Char] = char.filter("expected: open paren")(_ == '(').tag("(")
+    val paren2: Grammar[Any, Nothing, E, Char] = char.filter("expected: close paren")(_ == ')').tag(")")
 
     val plus: Grammar[Any, Nothing, E, Operator] = "+" @@ char.mapPartial("expected: '+'")(
       { case '+' => Add },

--- a/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
+++ b/src/test/scala/org/spartanz/parserz/ClassicExampleV2Spec.scala
@@ -84,7 +84,6 @@ class ClassicExampleV2Spec extends Specification {
         )
     }
 
-
     // todo: generalize fold/unfold
 
     private def fold2(z: Expression, list: List[(Operator, Expression)]): Expression =
@@ -99,7 +98,6 @@ class ClassicExampleV2Spec extends Specification {
       case o @ Operation(_, op2, _) if op2 != op => Some((o, acc))
       case _ @Operation(e1, `op`, e2)            => unfold2(op)((op, e2) :: acc)(e1)
     }
-
 
     val parser: (S, Input) => (S, E \/ (Input, Expression))  = Parser.parser[S, E, Expression](addition)
     val printer: (S, (Input, Expression)) => (S, E \/ Input) = Parser.printer[S, E, Expression](addition)

--- a/src/test/scala/org/spartanz/parserz/FunExampleSpec.scala
+++ b/src/test/scala/org/spartanz/parserz/FunExampleSpec.scala
@@ -1,0 +1,98 @@
+package org.spartanz.parserz
+
+import org.specs2.mutable.Specification
+
+class FunExampleSpec extends Specification {
+
+  object Stateless {
+
+    object Parser extends ParsersModule {
+      override type Input = String
+    }
+
+    type S = Unit
+    type E = String
+
+    import Parser._
+    import Parser.Grammar._
+
+    val good: Grammar[Any, Nothing, Nothing, String] = succeed("🎁")
+    val bad: Grammar[Any, Nothing, E, String]        = fail("🚫")
+
+    def parser[A](g: Grammar[Any, Nothing, E, A]): Input => E \/ (Input, A)    = Parser.parser[S, E, A](g)((), _)._2
+    def printer[A](g: Grammar[Any, Nothing, E, A]): ((Input, A)) => E \/ Input = Parser.printer[S, E, A](g)((), _)._2
+  }
+
+  "Stateless parser" should {
+    import Stateless._
+
+    "-> generate value" in {
+      parser(good)("abc") must_=== Right(("abc", "🎁"))
+    }
+    "<- ignore value" in {
+      printer(good)("abc" -> "🎁") must_=== Right("abc")
+    }
+
+    "-> generate error" in {
+      parser(bad)("abc") must_=== Left("🚫")
+    }
+    "<- generate error" in {
+      printer(bad)("abc" -> "🎁") must_=== Left("🚫")
+    }
+  }
+
+  object Stateful {
+
+    object Parser extends ParsersModule {
+      override type Input = String
+    }
+
+    type S = Int
+    type E = String
+
+    import Parser._
+    import Parser.Grammar._
+
+    val neutral: Grammar[Any, Nothing, E, Char] = consume0(
+      s => s.headOption.map(s.drop(1) -> _).map(Right(_)).getOrElse(Left("empty")),
+      { case (s, c) => Right(s + c.toString) }
+    )
+
+    val effectful: Grammar[S, S, E, Char] = consume(
+      { case (si, s)      => si + 1 -> s.headOption.map(s.drop(1) -> _).map(Right(_)).getOrElse(Left("empty")) },
+      { case (si, (s, c)) => si - 1 -> Right(s + c.toString) }
+    )
+
+    def parser[A](g: Grammar[S, S, E, A]): (S, Input) => (S, E \/ (Input, A))  = Parser.parser[S, E, A](g)
+    def printer[A](g: Grammar[S, S, E, A]): (S, (Input, A)) => (S, E \/ Input) = Parser.printer[S, E, A](g)
+  }
+
+  "Stateful parser" should {
+    import Stateful._
+
+    "-> consume value (no state change)" in {
+      parser(neutral)(0, "abc") must_=== ((0, Right(("bc", 'a'))))
+    }
+    "<- produce value (no state change)" in {
+      printer(neutral)(0, ("", 'a')) must_=== ((0, Right("a")))
+    }
+
+    "-> consume value (with state change)" in {
+      parser(effectful)(0, "abc") must_=== ((1, Right(("bc", 'a'))))
+    }
+    "<- produce value (with state change)" in {
+      printer(effectful)(0, ("", 'a')) must_=== ((-1, Right("a")))
+    }
+
+    "-> fail to consume value (with state change)" in {
+      parser(effectful)(0, "") must_=== ((1, Left("empty")))
+    }
+
+    "-> consume value (with more state change)" in {
+      parser(effectful ~ neutral ~ effectful)(0, "abc") must_=== ((2, Right(("", (('a', 'b'), 'c')))))
+    }
+    "<- produce value (with more state change)" in {
+      printer(effectful ~ neutral ~ effectful)(0, ("", (('a', 'b'), 'c'))) must_=== ((-2, Right("abc")))
+    }
+  }
+}

--- a/src/test/scala/org/spartanz/parserz/SimplestExampleV2Spec.scala
+++ b/src/test/scala/org/spartanz/parserz/SimplestExampleV2Spec.scala
@@ -5,7 +5,7 @@ import org.specs2.mutable.Specification
 
 import scala.annotation.tailrec
 
-class SimplestV2Spec extends Specification {
+class SimplestExampleV2Spec extends Specification {
 
   object Syntax {
     sealed trait Expression
@@ -55,13 +55,11 @@ class SimplestV2Spec extends Specification {
     def unfold2[D](separator: D)(acc: List[(D, Expression)])(e: Expression): (Expression, List[(D, Expression)]) =
       e match {
         case c @ Constant(_) => (c, acc)
-        case _ @Sum(e1, e2)  => unfold2(separator)((separator, e2) :: acc)(e1)
+        case _ @ Sum(e1, e2)  => unfold2(separator)((separator, e2) :: acc)(e1)
       }
 
     val parser: (S, Input) => (S, E \/ (Input, Expression)) = Parser.parser[S, E, Expression](expr2)
-
-    val printer: (S, (Input, Expression)) => (S, E \/ Input) =
-      Parser.printer[S, E, Expression](expr2)
+    val printer: (S, (Input, Expression)) => (S, E \/ Input) = Parser.printer[S, E, Expression](expr2)
   }
 
   import Syntax._

--- a/src/test/scala/org/spartanz/parserz/SimplestExampleV2Spec.scala
+++ b/src/test/scala/org/spartanz/parserz/SimplestExampleV2Spec.scala
@@ -55,7 +55,7 @@ class SimplestExampleV2Spec extends Specification {
     def unfold2[D](separator: D)(acc: List[(D, Expression)])(e: Expression): (Expression, List[(D, Expression)]) =
       e match {
         case c @ Constant(_) => (c, acc)
-        case _ @ Sum(e1, e2)  => unfold2(separator)((separator, e2) :: acc)(e1)
+        case _ @Sum(e1, e2)  => unfold2(separator)((separator, e2) :: acc)(e1)
       }
 
     val parser: (S, Input) => (S, E \/ (Input, Expression))  = Parser.parser[S, E, Expression](expr2)

--- a/src/test/scala/org/spartanz/parserz/SimplestExampleV2Spec.scala
+++ b/src/test/scala/org/spartanz/parserz/SimplestExampleV2Spec.scala
@@ -58,7 +58,7 @@ class SimplestExampleV2Spec extends Specification {
         case _ @ Sum(e1, e2)  => unfold2(separator)((separator, e2) :: acc)(e1)
       }
 
-    val parser: (S, Input) => (S, E \/ (Input, Expression)) = Parser.parser[S, E, Expression](expr2)
+    val parser: (S, Input) => (S, E \/ (Input, Expression))  = Parser.parser[S, E, Expression](expr2)
     val printer: (S, (Input, Expression)) => (S, E \/ Input) = Parser.printer[S, E, Expression](expr2)
   }
 

--- a/src/test/scala/org/spartanz/parserz/SimplestExampleV2Spec.scala
+++ b/src/test/scala/org/spartanz/parserz/SimplestExampleV2Spec.scala
@@ -26,15 +26,15 @@ class SimplestExampleV2Spec extends Specification {
     import Parser._
     import Parser.Grammar._
 
-    val char: Grammar[Any, Nothing, E, Char] = consumeOptional0[E, Char]("expected: char")(
+    val char: Grammar[Any, Nothing, E, Char] = consumeOptional0("expected: char")(
       s => s.headOption.map(s.drop(1) -> _),
       { case (s, c) => Some(s + c.toString) }
     )
 
     val digit: Grammar[Any, Nothing, E, Char]        = char.filter("expected: digit")(_.isDigit)
     val plus: Grammar[Any, Nothing, E, Char]         = char.filter("expected: '+'")(_ == '+')
-    val integer: Grammar[Any, Nothing, E, Int]       = digit.map(_.toString.toInt, _.toString.head)
-    val constant: Grammar[Any, Nothing, E, Constant] = integer.map(Constant, _.value)
+    val integer: Grammar[Any, Nothing, E, Int]       = digit ∘ (_.toString.toInt, _.toString.head)
+    val constant: Grammar[Any, Nothing, E, Constant] = integer ∘ (Constant, _.value)
 
     val expr1: Grammar[Any, Nothing, E, Expression] = constant.mapPartial("expected: Constant")(
       { case c               => c },

--- a/src/test/scala/org/spartanz/parserz/SimplestV2Spec.scala
+++ b/src/test/scala/org/spartanz/parserz/SimplestV2Spec.scala
@@ -1,0 +1,108 @@
+package org.spartanz.parserz
+
+import org.specs2.matcher.MatchResult
+import org.specs2.mutable.Specification
+
+import scala.annotation.tailrec
+
+class SimplestV2Spec extends Specification {
+
+  object Syntax {
+    sealed trait Expression
+    case class Constant(value: Int)                extends Expression
+    case class Sum(e1: Expression, e2: Expression) extends Expression
+  }
+
+  object Example {
+
+    object Parser extends ParsersModule {
+      override type Input = String
+    }
+
+    type S = Unit
+    type E = String
+
+    import Syntax._
+    import Parser._
+    import Parser.Grammar._
+
+    val char: Grammar[Any, Nothing, E, Char] = consumeOptional0[E, Char]("expected: char")(
+      s => s.headOption.map(s.drop(1) -> _),
+      { case (s, c) => Some(s + c.toString) }
+    )
+
+    val digit: Grammar[Any, Nothing, E, Char]        = char.filter("expected: digit")(_.isDigit)
+    val plus: Grammar[Any, Nothing, E, Char]         = char.filter("expected: '+'")(_ == '+')
+    val integer: Grammar[Any, Nothing, E, Int]       = digit.map(_.toString.toInt, _.toString.head)
+    val constant: Grammar[Any, Nothing, E, Constant] = integer.map(Constant, _.value)
+
+    val expr1: Grammar[Any, Nothing, E, Expression] = constant.mapPartial("expected: Constant")(
+      { case c               => c },
+      { case c @ Constant(_) => c }
+    )
+
+    val expr2: Grammar[Any, Nothing, E, Expression] = (expr1 ~ (plus ~ expr1).rep).map(
+      (fold2 _).tupled,
+      unfold2('+')(Nil)
+    )
+
+    // todo: generalize fold/unfold
+
+    def fold2[D](z: Expression, list: List[(D, Expression)]): Expression =
+      list.foldLeft(z) { case (e1, (_, e2)) => Sum(e1, e2) }
+
+    @tailrec
+    def unfold2[D](separator: D)(acc: List[(D, Expression)])(e: Expression): (Expression, List[(D, Expression)]) =
+      e match {
+        case c @ Constant(_) => (c, acc)
+        case _ @Sum(e1, e2)  => unfold2(separator)((separator, e2) :: acc)(e1)
+      }
+
+    val parser: (S, Input) => (S, E \/ (Input, Expression)) = Parser.parser[S, E, Expression](expr2)
+
+    val printer: (S, (Input, Expression)) => (S, E \/ Input) =
+      Parser.printer[S, E, Expression](expr2)
+  }
+
+  import Syntax._
+
+  private def parse(s: String)  = Example.parser((), s)._2
+  private def parse0(s: String) = parse(s).right.get._2
+
+  private def print(e: Expression)  = Example.printer((), ("", e))._2
+  private def print0(e: Expression) = print(e).right.get
+
+  private def loop0(s: String, e: Expression): MatchResult[Any] = {
+    val parsed  = parse0(s)
+    val printed = print0(parsed)
+    (parsed must_=== e).and(printed must_=== s)
+  }
+
+  "empty" in {
+    parse("") must_=== Left("expected: char")
+  }
+  "single letter" in {
+    parse("A") must_=== Left("expected: digit")
+  }
+  "single digit" in {
+    loop0("1", Constant(1))
+  }
+  "several digits" in {
+    parse("12") must_=== Right(("2", Constant(1)))
+  }
+  "just the plus" in {
+    parse("+") must_=== Left("expected: digit")
+  }
+  "sum of two" in {
+    loop0("1+2", Sum(Constant(1), Constant(2)))
+  }
+  "sum of three" in {
+    loop0("1+2+3", Sum(Sum(Constant(1), Constant(2)), Constant(3)))
+  }
+  "sum of four" in {
+    loop0("1+2+3+4", Sum(Sum(Sum(Constant(1), Constant(2)), Constant(3)), Constant(4)))
+  }
+  "incorrect composed sum of three" in {
+    print(Sum(Constant(1), Sum(Constant(2), Constant(3)))) must_=== Left("expected: Constant")
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.2-SNAPSHOT"
+version in ThisBuild := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
Connects #49 

`ParsersModule.scala` implements the design suggested by @jdegoes based on free encoding.

Several examples are ported to be powered by new implementation, see `ClassicExampleV2Spec` for instance.

Thanks!
