### PR TITLE
Enabling cross compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,11 +36,12 @@ lazy val root =
   (project in file("."))
     .settings(
       name := "parserz",
-      scalaVersion := "2.12.10",
-      scalacOptions ++= Seq("-Xsource:2.13"),
+      scalaVersion := "2.13.1",
+      crossScalaVersions := Seq("2.12.10", "2.13.1"),
+      scalacOptions --= Seq("-Yno-adapted-args", "-Ypartial-unification"),
       libraryDependencies ++= Seq(
-        compilerPlugin("org.typelevel" %% "kind-projector"     % "0.10.3"),
-        compilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1"),
+        compilerPlugin(("org.typelevel" % "kind-projector" % "0.11.0").cross(CrossVersion.full)),
+        compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
         "org.specs2" %% "specs2-core" % "4.8.0" % Test
       )
     )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.8
+sbt.version = 1.3.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo"    % "0.9.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage"    % "1.6.0")
 addSbtPlugin("com.geirsson"  % "sbt-ci-release"   % "1.2.6")
-addSbtPlugin("org.spartanz"  % "sbt-org-policies" % "0.1.1")
+addSbtPlugin("org.spartanz"  % "sbt-org-policies" % "0.1.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.eed3si9n"  % "sbt-buildinfo"    % "0.9.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage"    % "1.6.0")
 addSbtPlugin("com.geirsson"  % "sbt-ci-release"   % "1.2.6")
-addSbtPlugin("org.spartanz"  % "sbt-org-policies" % "0.1.0")
+addSbtPlugin("org.spartanz"  % "sbt-org-policies" % "0.1.1")


### PR DESCRIPTION
This PR  : 
- changes default scala version to `2.13.1`
- enables cross-compilation for scala `2.12.10` and `2.13.1`
- update sbt to latest `1.3.3` version
- removes `-Yno-adapted-args` and `-Ypartial-unification` compiler flags which are not supported in `2.13` anymore

Last commit assumes next version of `sbt-org-policies` is going to be `0.1.2` so PR will fail :warning: 
However, when the new plugin is going to be released, everything should be :heavy_check_mark: 